### PR TITLE
20 featui 관광지 주변 음식점 상세 정보 view

### DIFF
--- a/app/src/main/java/com/example/leaveit/data/detail_restraunt/DetailRestrauntDataMapper.kt
+++ b/app/src/main/java/com/example/leaveit/data/detail_restraunt/DetailRestrauntDataMapper.kt
@@ -1,0 +1,7 @@
+package com.example.leaveit.data.detail_restraunt
+
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
+
+interface DetailRestrauntDataMapper {
+    fun toDomain() : DetailRestrauntDomainModel
+}

--- a/app/src/main/java/com/example/leaveit/data/detail_restraunt/DetailRestrauntDataSource.kt
+++ b/app/src/main/java/com/example/leaveit/data/detail_restraunt/DetailRestrauntDataSource.kt
@@ -1,0 +1,7 @@
+package com.example.leaveit.data.detail_restraunt
+
+import com.example.leaveit.data.model.DetailRestrauntDataModel
+
+interface DetailRestrauntDataSource {
+    suspend fun getDetailRestrauntData(value : String) : DetailRestrauntDataModel
+}

--- a/app/src/main/java/com/example/leaveit/data/detail_restraunt/DetailRestrauntRepositoryImpl.kt
+++ b/app/src/main/java/com/example/leaveit/data/detail_restraunt/DetailRestrauntRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.example.leaveit.data.detail_restraunt
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
+import com.example.leaveit.domain.repository.DetailRestrauntRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class DetailRestrauntRepositoryImpl @Inject constructor(
+    private val bindDetailRestrauntDataSource : DetailRestrauntDataSource
+) : DetailRestrauntRepository {
+    override suspend fun getDertailRestrauntData(value: String): Flow<DataResource<DetailRestrauntDomainModel>> = flow {
+        emit(DataResource.Loading())
+
+        try{
+            val data = bindDetailRestrauntDataSource.getDetailRestrauntData(value)
+            emit(DataResource.success(data.toDomain()))
+
+
+        }catch (e : Exception){
+            emit(DataResource.error(e))
+        }
+    }
+}

--- a/app/src/main/java/com/example/leaveit/data/model/DetailRestrauntDataModel.kt
+++ b/app/src/main/java/com/example/leaveit/data/model/DetailRestrauntDataModel.kt
@@ -1,0 +1,24 @@
+package com.example.leaveit.data.model
+
+import com.example.leaveit.data.detail_restraunt.DetailRestrauntDataMapper
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
+
+data class DetailRestrauntDataModel(
+    val firstmenu: String,
+    val treatmenu: String,
+    val parkingfood: String,
+    val infocenterfood: String,
+    val opentimefood: String,
+    val restdatefood: String,
+) : DetailRestrauntDataMapper {
+    override fun toDomain(): DetailRestrauntDomainModel {
+        return DetailRestrauntDomainModel(
+            firstmenu = this.firstmenu,
+            treatmenu = this.treatmenu,
+            parkingfood = this.parkingfood,
+            infocenterfood = this.infocenterfood,
+            opentimefood = this.opentimefood,
+            restdatefood = this.restdatefood
+        )
+    }
+}

--- a/app/src/main/java/com/example/leaveit/data/model/RestrauntDataModel.kt
+++ b/app/src/main/java/com/example/leaveit/data/model/RestrauntDataModel.kt
@@ -14,7 +14,8 @@ data class RestrauntDataListModel(
                 longitutde = it.longitutde,
                 langtitude = it.langtitude,
                 image = it.image ?: "",
-                contentid = it.contentid
+                contentid = it.contentid,
+                addr = it.addr
             )
         }
 
@@ -27,6 +28,7 @@ data class RestrauntDataListModel(
 data class RestrauntDataModel(
     val title : String,
     val contentid : String,
+    val addr : String,
     val image : String?,
     val longitutde : String,
     val langtitude : String

--- a/app/src/main/java/com/example/leaveit/data/model/RestrauntDataModel.kt
+++ b/app/src/main/java/com/example/leaveit/data/model/RestrauntDataModel.kt
@@ -1,0 +1,33 @@
+package com.example.leaveit.data.model
+
+import com.example.leaveit.data.restraunt.RestrauntDataMapper
+import com.example.leaveit.domain.model.RestrantListDomainModel
+import com.example.leaveit.domain.model.RestrauntDomainModel
+
+data class RestrauntDataListModel(
+    val dataList : List<RestrauntDataModel>
+) : RestrauntDataMapper {
+    override fun toDomain(): RestrantListDomainModel {
+        val temp = this.dataList.map {
+            RestrauntDomainModel(
+                title = it.title,
+                longitutde = it.longitutde,
+                langtitude = it.langtitude,
+                image = it.image ?: "",
+                contentid = it.contentid
+            )
+        }
+
+        return RestrantListDomainModel(
+            list = temp
+        )
+    }
+}
+
+data class RestrauntDataModel(
+    val title : String,
+    val contentid : String,
+    val image : String?,
+    val longitutde : String,
+    val langtitude : String
+)

--- a/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntDataMapper.kt
+++ b/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntDataMapper.kt
@@ -1,0 +1,7 @@
+package com.example.leaveit.data.restraunt
+
+import com.example.leaveit.domain.model.RestrantListDomainModel
+
+interface RestrauntDataMapper {
+    fun toDomain() : RestrantListDomainModel
+}

--- a/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntDataSource.kt
+++ b/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntDataSource.kt
@@ -1,0 +1,8 @@
+package com.example.leaveit.data.restraunt
+
+import com.example.leaveit.data.model.RestrauntDataListModel
+
+interface RestrauntDataSource {
+
+    suspend fun getRestrauntData(longitude : String, latitude : String) : RestrauntDataListModel
+}

--- a/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntRepsitoryImpl.kt
+++ b/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntRepsitoryImpl.kt
@@ -4,22 +4,21 @@ import com.example.leaveit.dataResource.DataResource
 import com.example.leaveit.domain.model.RestrantListDomainModel
 import com.example.leaveit.domain.repository.RestrauntRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RestrauntRepsitoryImpl @Inject constructor(
-    val bindRestrauntDataSourceImpl: RestrauntDataSource
+    private val bindRestrauntDataSourceImpl: RestrauntDataSource
 ) : RestrauntRepository {
     override suspend fun getRestrauntData(
         longitude: String,
         latitude: String
-    ): Flow<DataResource<RestrantListDomainModel>> = flow{
+    ): Flow<DataResource<RestrantListDomainModel>> = flow {
         emit(DataResource.Loading())
-        try{
-            val result = bindRestrauntDataSourceImpl.getRestrauntData(longitude,latitude)
-            emit(DataResource.success(result.toDomain()))
-        }catch (e : Exception){
-            emit(DataResource.error(e))
-        }
+        val result = bindRestrauntDataSourceImpl.getRestrauntData(longitude, latitude)
+        emit(DataResource.success(result.toDomain()))
+    }.catch { e ->
+        emit(DataResource.error(e))
     }
 }

--- a/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntRepsitoryImpl.kt
+++ b/app/src/main/java/com/example/leaveit/data/restraunt/RestrauntRepsitoryImpl.kt
@@ -1,0 +1,25 @@
+package com.example.leaveit.data.restraunt
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.RestrantListDomainModel
+import com.example.leaveit.domain.repository.RestrauntRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RestrauntRepsitoryImpl @Inject constructor(
+    val bindRestrauntDataSourceImpl: RestrauntDataSource
+) : RestrauntRepository {
+    override suspend fun getRestrauntData(
+        longitude: String,
+        latitude: String
+    ): Flow<DataResource<RestrantListDomainModel>> = flow{
+        emit(DataResource.Loading())
+        try{
+            val result = bindRestrauntDataSourceImpl.getRestrauntData(longitude,latitude)
+            emit(DataResource.success(result.toDomain()))
+        }catch (e : Exception){
+            emit(DataResource.error(e))
+        }
+    }
+}

--- a/app/src/main/java/com/example/leaveit/di/DBModule.kt
+++ b/app/src/main/java/com/example/leaveit/di/DBModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import com.example.leaveit.local.AppDatabase
 import com.example.leaveit.remote.api.NavigateApiService
+import com.example.leaveit.remote.api.Restraunt.RestrauntAPI
 import com.example.leaveit.remote.api.RetrofitService
 import com.example.leaveit.remote.api.TourApiRetrofitService
 import com.example.leaveit.remote.api.navigate.NavigateAPI
@@ -51,6 +52,12 @@ object DBModule {
     @Singleton
     fun provideNavigateApiService() : NavigateAPI{
         return NavigateApiService.retrofit.create(NavigateAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRestrauntApiService() : RestrauntAPI{
+        return TourApiRetrofitService.retrofit.create(RestrauntAPI::class.java)
     }
 
     @Provides

--- a/app/src/main/java/com/example/leaveit/di/DBModule.kt
+++ b/app/src/main/java/com/example/leaveit/di/DBModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import com.example.leaveit.local.AppDatabase
 import com.example.leaveit.remote.api.NavigateApiService
+import com.example.leaveit.remote.api.Restraunt.DetailRestrauntAPI
 import com.example.leaveit.remote.api.Restraunt.RestrauntAPI
 import com.example.leaveit.remote.api.RetrofitService
 import com.example.leaveit.remote.api.TourApiRetrofitService
@@ -58,6 +59,12 @@ object DBModule {
     @Singleton
     fun provideRestrauntApiService() : RestrauntAPI{
         return TourApiRetrofitService.retrofit.create(RestrauntAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideDetailRestrauntApiService() : DetailRestrauntAPI{
+        return TourApiRetrofitService.retrofit.create(DetailRestrauntAPI::class.java)
     }
 
     @Provides

--- a/app/src/main/java/com/example/leaveit/di/DetailRestrauntModule.kt
+++ b/app/src/main/java/com/example/leaveit/di/DetailRestrauntModule.kt
@@ -1,0 +1,27 @@
+package com.example.leaveit.di
+
+import com.example.leaveit.data.detail_restraunt.DetailRestrauntDataSource
+import com.example.leaveit.data.detail_restraunt.DetailRestrauntRepositoryImpl
+import com.example.leaveit.domain.repository.DetailRestrauntRepository
+import com.example.leaveit.domain.usecase.detail_restraunt.DetailRestrauntUseCase
+import com.example.leaveit.domain.usecase.detail_restraunt.DetailRestrauntUseCaseImpl
+import com.example.leaveit.remote.detail_restraunt.DetailRestrauntDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DetailRestrauntModule {
+
+    @Binds
+    abstract fun bindDetailRestrauntDataSource(bindDetailRestrauntDataSource : DetailRestrauntDataSourceImpl) : DetailRestrauntDataSource
+
+    @Binds
+    abstract fun bindDetailRestrauntRespository(bindDetailRestrauntRespository : DetailRestrauntRepositoryImpl) : DetailRestrauntRepository
+
+    @Binds
+    abstract fun bindDetailRestrauntUseCase(bindDetailRestrauntUseCase : DetailRestrauntUseCaseImpl) : DetailRestrauntUseCase
+
+}

--- a/app/src/main/java/com/example/leaveit/di/RestrauntModule.kt
+++ b/app/src/main/java/com/example/leaveit/di/RestrauntModule.kt
@@ -1,0 +1,27 @@
+package com.example.leaveit.di
+
+import com.example.leaveit.data.restraunt.RestrauntDataSource
+import com.example.leaveit.data.restraunt.RestrauntRepsitoryImpl
+import com.example.leaveit.domain.repository.RestrauntRepository
+import com.example.leaveit.domain.usecase.restraunt.RestrauntUseCase
+import com.example.leaveit.domain.usecase.restraunt.RestrauntUseCaseImpl
+import com.example.leaveit.remote.restraunt.RestrauntDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RestrauntModule {
+
+    @Binds
+    abstract fun bindRestrauntDataSourceImpl(bindRestrauntDataSourceImpl : RestrauntDataSourceImpl) : RestrauntDataSource
+
+    @Binds
+    abstract fun bindRestrauntRespoitoryImpl(bindRestrauntRespoitoryImpl : RestrauntRepsitoryImpl) : RestrauntRepository
+
+    @Binds
+    abstract fun bindRestrauntUseCaseImpl(bindRestrauntUseCaseImpl : RestrauntUseCaseImpl) : RestrauntUseCase
+
+}

--- a/app/src/main/java/com/example/leaveit/domain/model/DetailRestrauntDomainModel.kt
+++ b/app/src/main/java/com/example/leaveit/domain/model/DetailRestrauntDomainModel.kt
@@ -1,0 +1,10 @@
+package com.example.leaveit.domain.model
+
+data class DetailRestrauntDomainModel(
+    val firstmenu: String,
+    val treatmenu: String,
+    val parkingfood: String,
+    val infocenterfood: String,
+    val opentimefood: String,
+    val restdatefood: String,
+)

--- a/app/src/main/java/com/example/leaveit/domain/model/RestrauntDomainModel.kt
+++ b/app/src/main/java/com/example/leaveit/domain/model/RestrauntDomainModel.kt
@@ -1,0 +1,13 @@
+package com.example.leaveit.domain.model
+
+data class RestrantListDomainModel(
+    val list : List<RestrauntDomainModel>
+)
+
+data class RestrauntDomainModel(
+    val title : String,
+    val contentid : String,
+    val image : String?,
+    val longitutde : String,
+    val langtitude : String
+)

--- a/app/src/main/java/com/example/leaveit/domain/model/RestrauntDomainModel.kt
+++ b/app/src/main/java/com/example/leaveit/domain/model/RestrauntDomainModel.kt
@@ -7,6 +7,7 @@ data class RestrantListDomainModel(
 data class RestrauntDomainModel(
     val title : String,
     val contentid : String,
+    val addr : String,
     val image : String?,
     val longitutde : String,
     val langtitude : String

--- a/app/src/main/java/com/example/leaveit/domain/repository/DetailRestrauntRepository.kt
+++ b/app/src/main/java/com/example/leaveit/domain/repository/DetailRestrauntRepository.kt
@@ -1,0 +1,9 @@
+package com.example.leaveit.domain.repository
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
+import kotlinx.coroutines.flow.Flow
+
+interface DetailRestrauntRepository {
+    suspend fun getDertailRestrauntData(value : String) : Flow<DataResource<DetailRestrauntDomainModel>>
+}

--- a/app/src/main/java/com/example/leaveit/domain/repository/RestrauntRepository.kt
+++ b/app/src/main/java/com/example/leaveit/domain/repository/RestrauntRepository.kt
@@ -1,0 +1,10 @@
+package com.example.leaveit.domain.repository
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.RestrantListDomainModel
+import kotlinx.coroutines.flow.Flow
+
+interface RestrauntRepository {
+
+    suspend fun getRestrauntData(longitude : String, latitude : String) : Flow<DataResource<RestrantListDomainModel>>
+}

--- a/app/src/main/java/com/example/leaveit/domain/usecase/detail_restraunt/DetailRestrauntUseCase.kt
+++ b/app/src/main/java/com/example/leaveit/domain/usecase/detail_restraunt/DetailRestrauntUseCase.kt
@@ -1,0 +1,9 @@
+package com.example.leaveit.domain.usecase.detail_restraunt
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
+import kotlinx.coroutines.flow.Flow
+
+interface DetailRestrauntUseCase {
+    suspend fun getData(value : String) : Flow<DataResource<DetailRestrauntDomainModel>>
+}

--- a/app/src/main/java/com/example/leaveit/domain/usecase/detail_restraunt/DetailRestrauntUseCaseImpl.kt
+++ b/app/src/main/java/com/example/leaveit/domain/usecase/detail_restraunt/DetailRestrauntUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package com.example.leaveit.domain.usecase.detail_restraunt
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
+import com.example.leaveit.domain.repository.DetailRestrauntRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class DetailRestrauntUseCaseImpl @Inject constructor(
+    private val bindDetailRestrauntRespository : DetailRestrauntRepository
+) : DetailRestrauntUseCase {
+    override suspend fun getData(value : String): Flow<DataResource<DetailRestrauntDomainModel>> {
+            return bindDetailRestrauntRespository.getDertailRestrauntData(value)
+    }
+}

--- a/app/src/main/java/com/example/leaveit/domain/usecase/restraunt/RestrauntUseCase.kt
+++ b/app/src/main/java/com/example/leaveit/domain/usecase/restraunt/RestrauntUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.leaveit.domain.usecase.restraunt
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.RestrantListDomainModel
+import kotlinx.coroutines.flow.Flow
+
+interface RestrauntUseCase {
+    suspend fun getRestrauntData(
+        longitude: String,
+        latitude: String
+    ): Flow<DataResource<RestrantListDomainModel>>
+}

--- a/app/src/main/java/com/example/leaveit/domain/usecase/restraunt/RestrauntUseCaseImpl.kt
+++ b/app/src/main/java/com/example/leaveit/domain/usecase/restraunt/RestrauntUseCaseImpl.kt
@@ -1,0 +1,19 @@
+package com.example.leaveit.domain.usecase.restraunt
+
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.RestrantListDomainModel
+import com.example.leaveit.domain.repository.RestrauntRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class RestrauntUseCaseImpl @Inject constructor(
+    val bindRestrauntRepsitoryImpl: RestrauntRepository
+) : RestrauntUseCase {
+    override suspend fun getRestrauntData(
+        longitude: String,
+        latitude: String
+    ): Flow<DataResource<RestrantListDomainModel>> {
+        return bindRestrauntRepsitoryImpl.getRestrauntData(longitude,latitude)
+    }
+
+}

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/place/detailplaceview/DetailPlaceView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/place/detailplaceview/DetailPlaceView.kt
@@ -16,6 +16,7 @@ import com.example.leaveit.R
 import com.example.leaveit.databinding.FragmentDetailplaceviewBinding
 import com.example.leaveit.presentation.placeview.place.navigateplaceview.NavigatePlaceView
 import com.example.leaveit.presentation.placeview.place.selectregionview.SelectRegionViewModel
+import com.example.leaveit.presentation.placeview.restraunt.RestrauntView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -47,6 +48,7 @@ class DetailPlaceView : Fragment() {
         observeContent()
         infoEventListener()
         moveToNavigatePlaceEventListener()
+        moveToRestrauntViewEventListener()
 
         observeDetailPlaceData()
 
@@ -101,6 +103,24 @@ class DetailPlaceView : Fragment() {
                 .replace(
                     R.id.selectregion_fragment_container,
                     NavigatePlaceView()
+                )
+                .commit()
+        }
+    }
+
+    private fun moveToRestrauntViewEventListener(){
+        binding.itemBtn2.setOnClickListener {
+            requireActivity().supportFragmentManager.beginTransaction()
+                .addToBackStack(null)
+                .setCustomAnimations(
+                    R.anim.fade_in_review_splash,
+                    R.anim.fade_out_review_splash,
+                    R.anim.fade_in_review_splash,
+                    R.anim.fade_out_review_splash
+                )
+                .replace(
+                    R.id.selectregion_fragment_container,
+                    RestrauntView()
                 )
                 .commit()
         }

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/place/navigateplaceview/NavigatePlaceView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/place/navigateplaceview/NavigatePlaceView.kt
@@ -60,7 +60,6 @@ class NavigatePlaceView : Fragment(), OnMapReadyCallback {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        //checkPermission()
 
         initData()
 
@@ -102,10 +101,13 @@ class NavigatePlaceView : Fragment(), OnMapReadyCallback {
                     lat = "37.160708".toDouble(),
                     lng = "127.1035862".toDouble()
                 )
-                    viewModel.setCenterLocation(
-                        LatLng(userLocationLat,userLocationLong),
-                        LatLng(rootViewModel.mapy.value!!.toDouble(),rootViewModel.mapx.value!!.toDouble())
+                viewModel.setCenterLocation(
+                    LatLng(userLocationLat, userLocationLong),
+                    LatLng(
+                        rootViewModel.mapy.value!!.toDouble(),
+                        rootViewModel.mapx.value!!.toDouble()
                     )
+                )
 
                 //"127.1035862,37.160708"
                 viewModel.getCurrentLocationAddress("127.1035862,37.160708") // 현 위치 받아오는 메서드
@@ -250,13 +252,13 @@ class NavigatePlaceView : Fragment(), OnMapReadyCallback {
     // 지도 설정 함수
     private fun setUtillFunctionMap(map: NaverMap) {
 
-      viewModel.locationDataForMap.observe(viewLifecycleOwner){(center,zoomLevel) ->
-          val cameraUpdate = CameraUpdate.scrollAndZoomTo(center, zoomLevel)
-          Log.d(TAG,"실제 줌 거리 : $zoomLevel")
-          map.moveCamera(cameraUpdate)
-          map.uiSettings.isRotateGesturesEnabled = false // 회전 비활성화
-          map.uiSettings.isTiltGesturesEnabled = false   // 기울이기 비활성화
-      }
+        viewModel.locationDataForMap.observe(viewLifecycleOwner) { (center, zoomLevel) ->
+            val cameraUpdate = CameraUpdate.scrollAndZoomTo(center, zoomLevel)
+            Log.d(TAG, "실제 줌 거리 : $zoomLevel")
+            map.moveCamera(cameraUpdate)
+            map.uiSettings.isRotateGesturesEnabled = false // 회전 비활성화
+            map.uiSettings.isTiltGesturesEnabled = false   // 기울이기 비활성화
+        }
     }
 
     private fun initData() {

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/DetailRestrauntView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/DetailRestrauntView.kt
@@ -6,10 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import com.bumptech.glide.Glide
 import com.example.leaveit.databinding.FragmentDetailrestrauntviewBinding
+import com.example.leaveit.presentation.placeview.place.selectregionview.SelectRegionViewModel
 
 class DetailRestrauntView : Fragment() {
     lateinit var binding: FragmentDetailrestrauntviewBinding
+    private val rootViewModel: SelectRegionViewModel by activityViewModels()
     private val viewModel: RestrauntViewModel by activityViewModels()
 
     override fun onCreateView(
@@ -25,6 +28,26 @@ class DetailRestrauntView : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initView()
+        initTopAppBarText()
+
+    }
+
+    private fun initView(){
+        val data = viewModel.selectRestrauntData.value
+
+        // 이미지 설정
+        Glide.with(binding.root)
+            .load(data!!.image)
+            .fitCenter()
+            .into(binding.placeImage)
+
+
+
+    }
+
+    private fun initTopAppBarText(){
+        rootViewModel.setTopTapContent(viewModel.selectRestrauntData.value!!.title)
     }
 
     companion object {

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/DetailRestrauntView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/DetailRestrauntView.kt
@@ -1,9 +1,12 @@
 package com.example.leaveit.presentation.placeview.restraunt
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.Glide
@@ -14,6 +17,7 @@ class DetailRestrauntView : Fragment() {
     lateinit var binding: FragmentDetailrestrauntviewBinding
     private val rootViewModel: SelectRegionViewModel by activityViewModels()
     private val viewModel: RestrauntViewModel by activityViewModels()
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -30,23 +34,50 @@ class DetailRestrauntView : Fragment() {
 
         initView()
         initTopAppBarText()
+        infoClickListener()
 
+        viewModel.selectRestrauntData.observe(viewLifecycleOwner) {
+            viewModel.getDetailRestrauntData(it.contentid)
+        }
+
+        viewModel.data.observe(viewLifecycleOwner) {
+            if (it != null) {
+                binding.playTimeInfo.text = it.opentimefood
+                binding.representativeMenuText.text = it.firstmenu
+                binding.mainIntroText.text = it.treatmenu
+            }
+        }
     }
 
-    private fun initView(){
+    private fun initView() {
         val data = viewModel.selectRestrauntData.value
+        if (data != null) {
 
-        // 이미지 설정
-        Glide.with(binding.root)
-            .load(data!!.image)
-            .fitCenter()
-            .into(binding.placeImage)
+            binding.placeTitleText.text = data.title
+            binding.addressInfo.text = data.addr
 
+            // 이미지 설정
+            Glide.with(binding.root)
+                .load(data.image)
+                .fitCenter()
+                .into(binding.placeImage)
 
+        }
 
     }
 
-    private fun initTopAppBarText(){
+    private fun infoClickListener() {
+        binding.infoImage.setOnClickListener {
+            if (viewModel.data.value?.infocenterfood?.isEmpty() == true) {
+                Toast.makeText(requireContext(), "등록된 번호가 없습니다", Toast.LENGTH_SHORT).show()
+            } else {
+                val uri = Uri.parse("tel:${viewModel.data.value?.infocenterfood}")
+                startActivity(Intent(Intent.ACTION_DIAL, uri))
+            }
+        }
+    }
+
+    private fun initTopAppBarText() {
         rootViewModel.setTopTapContent(viewModel.selectRestrauntData.value!!.title)
     }
 

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/DetailRestrauntView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/DetailRestrauntView.kt
@@ -1,0 +1,33 @@
+package com.example.leaveit.presentation.placeview.restraunt
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.example.leaveit.databinding.FragmentDetailrestrauntviewBinding
+
+class DetailRestrauntView : Fragment() {
+    lateinit var binding: FragmentDetailrestrauntviewBinding
+    private val viewModel: RestrauntViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentDetailrestrauntviewBinding.inflate(layoutInflater)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+    }
+
+    companion object {
+        const val TAG = "DetailRestrauntView"
+    }
+}

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntView.kt
@@ -1,0 +1,55 @@
+package com.example.leaveit.presentation.placeview.restraunt
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import com.example.leaveit.databinding.FragmentRestrauntviewBinding
+import com.example.leaveit.presentation.placeview.place.selectregionview.SelectRegionViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class RestrauntView : Fragment(){
+
+    lateinit var binding : FragmentRestrauntviewBinding
+    private val rootViewModel : SelectRegionViewModel by activityViewModels()
+    private val viewModel : RestrauntViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+
+        binding =  FragmentRestrauntviewBinding.inflate(layoutInflater)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val mapx = rootViewModel.mapx.value.toString()
+        val mapy = rootViewModel.mapy.value.toString()
+        Log.d(TAG,mapx)
+        Log.d(TAG,mapy)
+
+        viewModel.getRestrauntList(mapx,mapy)
+
+        viewModel.restrauntList.observe(viewLifecycleOwner){data ->
+            data.list.map {
+                    Log.d(TAG,it.title)
+                }
+        }
+
+
+    }
+
+
+    companion object{
+        const val TAG = "RestrauntView"
+    }
+}

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntView.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntView.kt
@@ -1,23 +1,36 @@
 package com.example.leaveit.presentation.placeview.restraunt
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
+import com.example.leaveit.R
 import com.example.leaveit.databinding.FragmentRestrauntviewBinding
+import com.example.leaveit.domain.model.RestrauntDomainModel
 import com.example.leaveit.presentation.placeview.place.selectregionview.SelectRegionViewModel
+import com.example.leaveit.utill.location.ClusterForMap
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraAnimation
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.clustering.ClusterMarkerInfo
+import com.naver.maps.map.clustering.Clusterer
+import com.naver.maps.map.clustering.DefaultClusterMarkerUpdater
+import com.naver.maps.map.clustering.DefaultLeafMarkerUpdater
+import com.naver.maps.map.clustering.LeafMarkerInfo
+import com.naver.maps.map.overlay.Marker
+import com.naver.maps.map.overlay.Overlay
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class RestrauntView : Fragment(){
+class RestrauntView : Fragment(), OnMapReadyCallback {
 
-    lateinit var binding : FragmentRestrauntviewBinding
-    private val rootViewModel : SelectRegionViewModel by activityViewModels()
-    private val viewModel : RestrauntViewModel by viewModels()
+    lateinit var binding: FragmentRestrauntviewBinding
+    private val rootViewModel: SelectRegionViewModel by activityViewModels()
+    private val viewModel: RestrauntViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,31 +38,113 @@ class RestrauntView : Fragment(){
         savedInstanceState: Bundle?
     ): View? {
 
-        binding =  FragmentRestrauntviewBinding.inflate(layoutInflater)
+        binding = FragmentRestrauntviewBinding.inflate(layoutInflater)
 
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+
+        // 관광지 좌표 호출
         val mapx = rootViewModel.mapx.value.toString()
         val mapy = rootViewModel.mapy.value.toString()
-        Log.d(TAG,mapx)
-        Log.d(TAG,mapy)
 
-        viewModel.getRestrauntList(mapx,mapy)
+        // 관광지 좌표 기반 근처 음식점 데이터 불러오기
+        viewModel.getRestrauntList(mapx, mapy)
 
-        viewModel.restrauntList.observe(viewLifecycleOwner){data ->
-            data.list.map {
-                    Log.d(TAG,it.title)
-                }
-        }
-
+        binding.naverMap.onCreate(savedInstanceState)
+        binding.naverMap.getMapAsync(this) // naverMap 객체 가져오기
 
     }
 
 
-    companion object{
+    override fun onMapReady(naverMap: NaverMap) {
+        // 카메라 세팅
+        setUtillFunctionMap(naverMap)
+
+        // 관광지 근처 음식점  마커 찍기
+        viewModel.restrauntList.observe(viewLifecycleOwner) { data ->
+
+            var dataSize = data.list.size - (data.list.size - 1) // 받아온 데이터 순회를 위한 변수 선언
+
+            val cluster: Clusterer<ClusterForMap> = Clusterer.Builder<ClusterForMap>()
+                .clusterMarkerUpdater(object : DefaultClusterMarkerUpdater() {
+                    override fun updateClusterMarker(info: ClusterMarkerInfo, marker: Marker) {
+                        super.updateClusterMarker(info, marker)
+                        // ✅ 클러스터 클릭 시 확대 (zoom in)
+                        marker.onClickListener = Overlay.OnClickListener {
+                            val clusterCenter = marker.position // 현재 클러스터 위치 받아오기
+                            val zoomLevel = naverMap.cameraPosition.zoom + 2.0 // 현재 카메라 줌에 + 2.0
+
+                            val cameraUpdate =
+                                CameraUpdate.scrollAndZoomTo(clusterCenter, zoomLevel)
+                                    .animate(CameraAnimation.Easing)
+                            naverMap.moveCamera(cameraUpdate) // 클릭하면 카메라 줌 업데이트
+
+                            true // 이벤트 처리 완료
+                        }
+
+                    }
+                }).leafMarkerUpdater(object : DefaultLeafMarkerUpdater() {
+                    override fun updateLeafMarker(info: LeafMarkerInfo, marker: Marker) {
+                        super.updateLeafMarker(info, marker)
+
+                        val selectedRestrauntData =
+                            info.tag as RestrauntDomainModel // 마커 데이터 접근을 위한 형변환
+
+                        marker.onClickListener = Overlay.OnClickListener {
+                            viewModel.setRestrauntData(selectedRestrauntData) // 클릭한 데이터 viewModel에 저장
+                            moveToDetailRestrauntView() // 저장 후 다음 화면으로 이동
+                            true
+                        }
+                    }
+                }).minZoom(4).maxZoom(16).animate(true).build()
+
+
+            data.list.map { item -> // 마커 데이터 클러스터에 추가
+                cluster.add(
+                    ClusterForMap(
+                        dataSize,
+                        LatLng(item.langtitude.toDouble(), item.longitutde.toDouble())
+                    ), item
+                )
+                dataSize++
+            }
+            cluster.map = naverMap
+        }
+    }
+
+    // 지도 설정 함수
+    private fun setUtillFunctionMap(map: NaverMap) {
+        val latLng =
+            LatLng(rootViewModel.mapy.value!!.toDouble(), rootViewModel.mapx.value!!.toDouble())
+
+        val cameraUpdate = CameraUpdate.scrollAndZoomTo(latLng, 15.0)
+        map.moveCamera(cameraUpdate)
+        map.uiSettings.isRotateGesturesEnabled = false // 회전 비활성화
+        map.uiSettings.isTiltGesturesEnabled = false   // 기울이기 비활성화
+    }
+
+    // 다음 화면 이동 함수
+    private fun moveToDetailRestrauntView() {
+        requireActivity().supportFragmentManager.beginTransaction()
+            .addToBackStack(null)
+            .setCustomAnimations(
+                R.anim.fade_in_review_splash,
+                R.anim.fade_out_review_splash,
+                R.anim.fade_in_review_splash,
+                R.anim.fade_out_review_splash
+            )
+            .replace(
+                R.id.selectregion_fragment_container,
+                DetailRestrauntView()
+            )
+            .commit()
+    }
+
+    companion object {
         const val TAG = "RestrauntView"
     }
 }

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntViewModel.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.leaveit.dataResource.DataResource
 import com.example.leaveit.domain.model.RestrantListDomainModel
+import com.example.leaveit.domain.model.RestrauntDomainModel
 import com.example.leaveit.domain.usecase.restraunt.RestrauntUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -19,6 +20,9 @@ class RestrauntViewModel @Inject constructor(
 
     private val _restrauntList : MutableLiveData<RestrantListDomainModel> by lazy { MutableLiveData() }
     val restrauntList : LiveData<RestrantListDomainModel> = _restrauntList
+
+    private val _selectRestrauntData : MutableLiveData<RestrauntDomainModel> by lazy { MutableLiveData() }
+    val selectRestrauntData : LiveData<RestrauntDomainModel> = _selectRestrauntData
 
 
 
@@ -34,6 +38,10 @@ class RestrauntViewModel @Inject constructor(
                 }
            }
        }
+    }
+
+    fun setRestrauntData(value : RestrauntDomainModel ){
+        _selectRestrauntData.value = value
     }
 
     companion object{

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntViewModel.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.leaveit.presentation.placeview.restraunt
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.RestrantListDomainModel
+import com.example.leaveit.domain.usecase.restraunt.RestrauntUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RestrauntViewModel @Inject constructor(
+    private val bindRestrauntUseCaseImpl: RestrauntUseCase
+) : ViewModel() {
+
+    private val _restrauntList : MutableLiveData<RestrantListDomainModel> by lazy { MutableLiveData() }
+    val restrauntList : LiveData<RestrantListDomainModel> = _restrauntList
+
+
+
+    fun getRestrauntList(longitude : String, latitude : String){
+       viewModelScope.launch {
+           bindRestrauntUseCaseImpl.getRestrauntData(longitude,latitude).collect{state ->
+                when(state){
+                    is DataResource.Error -> Log.e(TAG,state.throwable.message.toString())
+                    is DataResource.Loading -> Log.d(TAG,"음식점 정보 불러오는 중")
+                    is DataResource.Success -> {
+                        _restrauntList.value = state.data
+                    }
+                }
+           }
+       }
+    }
+
+    companion object{
+        const val TAG = "RestrauntViewModel"
+    }
+}

--- a/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntViewModel.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/placeview/restraunt/RestrauntViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.leaveit.dataResource.DataResource
+import com.example.leaveit.domain.model.DetailRestrauntDomainModel
 import com.example.leaveit.domain.model.RestrantListDomainModel
 import com.example.leaveit.domain.model.RestrauntDomainModel
+import com.example.leaveit.domain.usecase.detail_restraunt.DetailRestrauntUseCase
 import com.example.leaveit.domain.usecase.restraunt.RestrauntUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -15,7 +17,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RestrauntViewModel @Inject constructor(
-    private val bindRestrauntUseCaseImpl: RestrauntUseCase
+    private val bindRestrauntUseCaseImpl: RestrauntUseCase,
+    private val bindDetailRestrauntUseCaseImpl: DetailRestrauntUseCase
 ) : ViewModel() {
 
     private val _restrauntList : MutableLiveData<RestrantListDomainModel> by lazy { MutableLiveData() }
@@ -24,6 +27,8 @@ class RestrauntViewModel @Inject constructor(
     private val _selectRestrauntData : MutableLiveData<RestrauntDomainModel> by lazy { MutableLiveData() }
     val selectRestrauntData : LiveData<RestrauntDomainModel> = _selectRestrauntData
 
+    private val _data : MutableLiveData<DetailRestrauntDomainModel> by lazy { MutableLiveData() }
+    val data : LiveData<DetailRestrauntDomainModel> = _data
 
 
     fun getRestrauntList(longitude : String, latitude : String){
@@ -38,6 +43,19 @@ class RestrauntViewModel @Inject constructor(
                 }
            }
        }
+    }
+    fun getDetailRestrauntData(contentId : String){
+        viewModelScope.launch {
+            bindDetailRestrauntUseCaseImpl.getData(contentId).collect{state ->
+                when(state){
+                    is DataResource.Error -> Log.e(TAG,state.throwable.message.toString())
+                    is DataResource.Loading -> Log.d(TAG,"음식점 정보 불러오는 중")
+                    is DataResource.Success -> {
+                        _data.value = state.data
+                    }
+                }
+            }
+        }
     }
 
     fun setRestrauntData(value : RestrauntDomainModel ){

--- a/app/src/main/java/com/example/leaveit/presentation/review/SelectPlaceForReview.kt
+++ b/app/src/main/java/com/example/leaveit/presentation/review/SelectPlaceForReview.kt
@@ -86,7 +86,6 @@ class SelectPlaceForReview : Fragment(), OnMapReadyCallback {
         // 위경도 리스트와 NaverMap 객체를 마커 표시
             createMarker(locations, map)
 
-
     }
 
     // 지도 설정 함수

--- a/app/src/main/java/com/example/leaveit/remote/api/Restraunt/DetailRestrauntAPI.kt
+++ b/app/src/main/java/com/example/leaveit/remote/api/Restraunt/DetailRestrauntAPI.kt
@@ -1,0 +1,18 @@
+package com.example.leaveit.remote.api.Restraunt
+
+import com.example.leaveit.BuildConfig
+import com.example.leaveit.remote.entity.DetailRestrauntEntity
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface DetailRestrauntAPI {
+    @GET("detailIntro1")
+    suspend fun getDetailRestrauntData(
+        @Query("MobileOS") mobileOs : String = "AND",
+        @Query("MobileApp") mobileApp : String = "Leaveit",
+        @Query("serviceKey") serviceKey : String = BuildConfig.TOUR_API_KEY,
+        @Query("contentId") contentId : String,
+        @Query("contentTypeId") contentTypedId : String = "39",
+        @Query("_type") type : String = "json"
+    ) : DetailRestrauntEntity
+}

--- a/app/src/main/java/com/example/leaveit/remote/api/Restraunt/RestrauntAPI.kt
+++ b/app/src/main/java/com/example/leaveit/remote/api/Restraunt/RestrauntAPI.kt
@@ -1,0 +1,22 @@
+package com.example.leaveit.remote.api.Restraunt
+
+import com.example.leaveit.BuildConfig
+import com.example.leaveit.remote.entity.RestrauntEntity
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface RestrauntAPI {
+
+    @GET("locationBasedList1")
+    suspend fun getAllRegionPlace(
+        @Query("MobileOS") mobileOs : String = "AND",
+        @Query("MobileApp") mobileApp : String = "Leaveit",
+        @Query("serviceKey") serviceKey : String = BuildConfig.TOUR_API_KEY,
+        @Query("contentTypeId") contentTypedId : String = "39",
+        @Query("mapX") longitutde : String,
+        @Query("mapY") langitutde : String,
+        @Query("numOfRows") numOfRows : String = "10",
+        @Query("radius") radius : String = "3000",
+        @Query("_type") type : String = "json"
+    ) : RestrauntEntity
+}

--- a/app/src/main/java/com/example/leaveit/remote/api/TourApiRetrofitService.kt
+++ b/app/src/main/java/com/example/leaveit/remote/api/TourApiRetrofitService.kt
@@ -5,7 +5,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object TourApiRetrofitService {
-    private const val BASE_URL  = "http://apis.data.go.kr/B551011/KorService1/" // 에뮬레이터의 localhost는 10.0.2.2
+    private const val BASE_URL  = "http://apis.data.go.kr/B551011/KorService1/"
 
     var gson = GsonBuilder()
         .setLenient()

--- a/app/src/main/java/com/example/leaveit/remote/api/place/PlaceApi.kt
+++ b/app/src/main/java/com/example/leaveit/remote/api/place/PlaceApi.kt
@@ -26,7 +26,7 @@ interface PlaceApi {
         @Query("MobileApp") mobileApp : String = "AppTest",
         @Query("serviceKey") serviceKey : String,
         @Query("contentTypeId") contentTypedId : String,
-        @Query("numOfRows") numOfRows : String = "13112",
+        @Query("numOfRows") numOfRows : String = "50",
         @Query("areaCode") areaCode : String?,
         @Query("_type") type : String = "json"
     ) : firstResponse

--- a/app/src/main/java/com/example/leaveit/remote/detail_restraunt/DetailRestrauntDataSourceImpl.kt
+++ b/app/src/main/java/com/example/leaveit/remote/detail_restraunt/DetailRestrauntDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.example.leaveit.remote.detail_restraunt
+
+import com.example.leaveit.data.detail_restraunt.DetailRestrauntDataSource
+import com.example.leaveit.data.model.DetailRestrauntDataModel
+import com.example.leaveit.remote.api.Restraunt.DetailRestrauntAPI
+import javax.inject.Inject
+
+class DetailRestrauntDataSourceImpl @Inject constructor(
+    private val service : DetailRestrauntAPI
+) : DetailRestrauntDataSource{
+    override suspend fun getDetailRestrauntData(value : String): DetailRestrauntDataModel {
+        return service.getDetailRestrauntData(contentId = value).response.body.items.item[0].toData()
+    }
+}

--- a/app/src/main/java/com/example/leaveit/remote/detail_restraunt/DetailRestrauntEntityMapper.kt
+++ b/app/src/main/java/com/example/leaveit/remote/detail_restraunt/DetailRestrauntEntityMapper.kt
@@ -1,0 +1,7 @@
+package com.example.leaveit.remote.detail_restraunt
+
+import com.example.leaveit.data.model.DetailRestrauntDataModel
+
+interface DetailRestrauntEntityMapper {
+    fun toData() : DetailRestrauntDataModel
+}

--- a/app/src/main/java/com/example/leaveit/remote/entity/DetailRestrauntEntity.kt
+++ b/app/src/main/java/com/example/leaveit/remote/entity/DetailRestrauntEntity.kt
@@ -1,0 +1,48 @@
+package com.example.leaveit.remote.entity
+
+import com.example.leaveit.data.model.DetailRestrauntDataModel
+import com.example.leaveit.remote.detail_restraunt.DetailRestrauntEntityMapper
+import com.google.gson.annotations.SerializedName
+
+data class DetailRestrauntEntity(
+    val response: DetailRestrauntResponse
+)
+
+data class DetailRestrauntResponse(
+    @SerializedName("header") val header: DetailRestrauntHeader,
+    @SerializedName("body") val body: DetailRestrauntBody
+)
+
+data class DetailRestrauntHeader(
+    @SerializedName("resultCode") val resultCode: String,
+    @SerializedName("resultMsg") val resultMsg: String,
+)
+
+
+data class DetailRestrauntBody(
+    @SerializedName("items") val items: DetailRestrauntItems
+)
+
+data class DetailRestrauntItems(
+    @SerializedName("item") val item: List<DetailRestrauntItem>
+)
+
+data class DetailRestrauntItem(
+    @SerializedName("firstmenu") val firstmenu: String,
+    @SerializedName("treatmenu") val treatmenu: String,
+    @SerializedName("parkingfood") val parkingfood: String,
+    @SerializedName("infocenterfood") val infocenterfood: String,
+    @SerializedName("opentimefood") val opentimefood: String,
+    @SerializedName("restdatefood") val restdatefood: String,
+) : DetailRestrauntEntityMapper {
+    override fun toData(): DetailRestrauntDataModel {
+        return DetailRestrauntDataModel(
+            firstmenu = this.firstmenu,
+            treatmenu = this.treatmenu,
+            parkingfood = this.parkingfood,
+            infocenterfood = this.infocenterfood,
+            opentimefood = this.opentimefood,
+            restdatefood = this.restdatefood
+        )
+    }
+}

--- a/app/src/main/java/com/example/leaveit/remote/entity/RestrauntEntity.kt
+++ b/app/src/main/java/com/example/leaveit/remote/entity/RestrauntEntity.kt
@@ -1,0 +1,70 @@
+package com.example.leaveit.remote.entity
+
+import com.example.leaveit.data.model.RestrauntDataListModel
+import com.example.leaveit.data.model.RestrauntDataModel
+import com.example.leaveit.remote.restraunt.RestrauntEntityMapper
+import com.google.gson.annotations.SerializedName
+
+data class RestrauntEntity(
+    @SerializedName("response") val restrauntResponse: RestrauntResponse?
+)
+
+data class RestrauntResponse(
+    @SerializedName("header") val header: RestrauntHeader,
+    @SerializedName("body") val restrauntBody: RestrauntBody?,
+    @SerializedName("numOfRows") val numOfRows: Int,
+    @SerializedName("pageNo") val pageNo: Int,
+    @SerializedName("totalCount") val totalCount: Int
+)
+
+data class RestrauntHeader(
+    @SerializedName("resultCode") val resultCode: String,
+    @SerializedName("resultMsg") val resultMsg: String
+)
+
+data class RestrauntBody(
+    @SerializedName("items") val items: RestrauntItems,
+)
+
+data class RestrauntItems(
+    @SerializedName("item") val item: List<RestrauntItem>
+): RestrauntEntityMapper {
+    override fun toData(): RestrauntDataListModel {
+        val temp = this.item.map {
+            RestrauntDataModel(
+                contentid = it.contentid,
+                image = it.firstimage ?: "empty",
+                longitutde = it.mapx,
+                langtitude = it.mapy,
+                title = it.title
+            )
+        }
+        return RestrauntDataListModel(
+            dataList = temp
+        )
+    }
+}
+
+data class RestrauntItem(
+    @SerializedName("addr1") val addr1: String?,
+    @SerializedName("addr2") val addr2: String?,
+    @SerializedName("areacode") val areacode: String?,
+    @SerializedName("booktour") val booktour: String?,
+    @SerializedName("cat1") val cat1: String?,
+    @SerializedName("cat2") val cat2: String?,
+    @SerializedName("cat3") val cat3: String?,
+    @SerializedName("contentid") val contentid: String,
+    @SerializedName("contenttypeid") val contenttypeid: String,
+    @SerializedName("cpyrhtDivCd") val cpyrhtDivCd: String?,
+    @SerializedName("createdtime") val createdtime: String,
+    @SerializedName("dist") val dist: String,
+    @SerializedName("firstimage") val firstimage: String?,
+    @SerializedName("firstimage2") val firstimage2: String?,
+    @SerializedName("mapx") val mapx: String,
+    @SerializedName("mapy") val mapy: String,
+    @SerializedName("mlevel") val mlevel: String?,
+    @SerializedName("modifiedtime") val modifiedtime: String,
+    @SerializedName("sigungucode") val sigungucode: String?,
+    @SerializedName("tel") val tel: String?,
+    @SerializedName("title") val title: String
+)

--- a/app/src/main/java/com/example/leaveit/remote/entity/RestrauntEntity.kt
+++ b/app/src/main/java/com/example/leaveit/remote/entity/RestrauntEntity.kt
@@ -36,7 +36,8 @@ data class RestrauntItems(
                 image = it.firstimage ?: "empty",
                 longitutde = it.mapx,
                 langtitude = it.mapy,
-                title = it.title
+                title = it.title,
+                addr = it.addr1
             )
         }
         return RestrauntDataListModel(
@@ -46,7 +47,7 @@ data class RestrauntItems(
 }
 
 data class RestrauntItem(
-    @SerializedName("addr1") val addr1: String?,
+    @SerializedName("addr1") val addr1: String,
     @SerializedName("addr2") val addr2: String?,
     @SerializedName("areacode") val areacode: String?,
     @SerializedName("booktour") val booktour: String?,

--- a/app/src/main/java/com/example/leaveit/remote/restraunt/RestrauntDataSourceImpl.kt
+++ b/app/src/main/java/com/example/leaveit/remote/restraunt/RestrauntDataSourceImpl.kt
@@ -1,0 +1,33 @@
+package com.example.leaveit.remote.restraunt
+
+import android.util.Log
+import com.example.leaveit.data.model.RestrauntDataListModel
+import com.example.leaveit.data.restraunt.RestrauntDataSource
+import com.example.leaveit.remote.api.Restraunt.RestrauntAPI
+import javax.inject.Inject
+
+class RestrauntDataSourceImpl @Inject constructor(
+    private val service: RestrauntAPI
+) : RestrauntDataSource {
+    override suspend fun getRestrauntData(
+        longitude: String,
+        latitude: String
+    ): RestrauntDataListModel {
+        val temp = service.getAllRegionPlace(
+            longitutde = longitude,
+            langitutde = latitude
+        )
+
+        if (temp.restrauntResponse == null) {
+            Log.e("ERROR", "restrauntResponse가 null입니다.")
+            return RestrauntDataListModel(emptyList()) // 기본값 반환
+        }
+
+        if (temp.restrauntResponse.restrauntBody == null) {
+            Log.e("ERROR", "restrauntBody가 null입니다.")
+            return RestrauntDataListModel(emptyList()) // 기본값 반환
+        }
+
+        return temp.restrauntResponse.restrauntBody.items.toData()
+    }
+}

--- a/app/src/main/java/com/example/leaveit/remote/restraunt/RestrauntEntityMapper.kt
+++ b/app/src/main/java/com/example/leaveit/remote/restraunt/RestrauntEntityMapper.kt
@@ -1,0 +1,7 @@
+package com.example.leaveit.remote.restraunt
+
+import com.example.leaveit.data.model.RestrauntDataListModel
+
+interface RestrauntEntityMapper {
+    fun toData() : RestrauntDataListModel
+}

--- a/app/src/main/java/com/example/leaveit/utill/location/ClusterForMap.kt
+++ b/app/src/main/java/com/example/leaveit/utill/location/ClusterForMap.kt
@@ -1,0 +1,17 @@
+package com.example.leaveit.utill.location
+
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.clustering.ClusteringKey
+
+class ClusterForMap(val id: Int, private val position: LatLng) : ClusteringKey {
+    override fun getPosition() = position
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        val itemKey = other as ClusterForMap
+        return id == itemKey.id
+    }
+
+    override fun hashCode() = id
+}

--- a/app/src/main/res/drawable/info_icon.xml
+++ b/app/src/main/res/drawable/info_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="38dp"
-    android:height="38dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="960"
     android:viewportHeight="960">
   <path

--- a/app/src/main/res/drawable/parking_info.xml
+++ b/app/src/main/res/drawable/parking_info.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M240,840v-720h280q100,0 170,70t70,170q0,100 -70,170t-170,70L400,600v240L240,840ZM400,440h128q33,0 56.5,-23.5T608,360q0,-33 -23.5,-56.5T528,280L400,280v160Z"
+      android:fillColor="#31511E"/>
+</vector>

--- a/app/src/main/res/layout/fragment_detailplaceview.xml
+++ b/app/src/main/res/layout/fragment_detailplaceview.xml
@@ -174,12 +174,12 @@
                     app:layout_constraintTop_toBottomOf="@id/itemBtn3"
                     app:layout_constraintVertical_weight="0.4" />
 
-                <androidx.appcompat.widget.AppCompatImageButton
+                <ImageView
                     android:id="@+id/itemBtn4"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
                     android:background="@color/white"
-                    android:src="@drawable/info_24dp_31511e_fill0_wght400_grad0_opsz24"
+                    android:src="@drawable/info_icon"
                     app:layout_constraintBottom_toTopOf="@id/itemBtnText4"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/itemBtn3"

--- a/app/src/main/res/layout/fragment_detailrestrauntview.xml
+++ b/app/src/main/res/layout/fragment_detailrestrauntview.xml
@@ -90,7 +90,7 @@
             android:outlineAmbientShadowColor="@color/black"
             android:outlineSpotShadowColor="@color/black"
             app:layout_constraintBottom_toTopOf="@id/infoTextLayer"
-            app:layout_constraintDimensionRatio="24:5"
+            app:layout_constraintDimensionRatio="16:3"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/placeInfoLayer"
@@ -127,12 +127,11 @@
                     app:layout_constraintTop_toBottomOf="@id/parkingImage"
                     app:layout_constraintVertical_weight="0.5" />
 
-                <androidx.appcompat.widget.AppCompatImageButton
+                <ImageView
                     android:id="@+id/infoImage"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
-                    android:background="@color/white"
-                    android:src="@drawable/info_24dp_31511e_fill0_wght400_grad0_opsz24"
+                    android:src="@drawable/info_icon"
                     app:layout_constraintBottom_toTopOf="@id/infoText"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_weight="0.1"

--- a/app/src/main/res/layout/fragment_detailrestrauntview.xml
+++ b/app/src/main/res/layout/fragment_detailrestrauntview.xml
@@ -2,9 +2,5 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <com.naver.maps.map.MapView
-        android:id="@+id/naverMap"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_detailrestrauntview.xml
+++ b/app/src/main/res/layout/fragment_detailrestrauntview.xml
@@ -1,6 +1,225 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_margin="8dp"
+    android:fillViewport="true"
+    android:scrollbars="none">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <FrameLayout
+            android:id="@+id/imageLayer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/white"
+            app:layout_constraintBottom_toTopOf="@id/placeInfoLayer"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_weight="0.5">
+
+            <ImageView
+                android:id="@+id/placeImage"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:adjustViewBounds="true"
+                android:scaleType="centerCrop"
+                android:src="@drawable/star_icon" />
+
+            <TextView
+                android:id="@+id/placeTitleText"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="16dp"
+                android:gravity="bottom"
+                android:text="경복궁"
+                android:textColor="@color/white"
+                android:textSize="24dp" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:id="@+id/placeInfoLayer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:background="@color/white"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@id/functionInfoLayer"
+            app:layout_constraintDimensionRatio="24:8"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/imageLayer"
+            app:layout_constraintVertical_weight="0.02">
+
+            <TextView
+                android:id="@+id/addressInfo"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="0.3"
+                android:text="서울 종로구 사직로 161 경복궁"
+                android:textSize="24dp" />
+
+            <TextView
+                android:id="@+id/playTimeInfo"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginBottom="8dp"
+                android:layout_weight="0.3"
+                android:text="운영시간  10:00 ~ 20:00"
+                android:textSize="24dp" />
+
+            <TextView
+                android:id="@+id/restDayInfo"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="0.3"
+                android:text="쉬는날  매주 화요일"
+                android:textSize="24dp" />
+        </LinearLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/functionInfoLayer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:outlineAmbientShadowColor="@color/black"
+            android:outlineSpotShadowColor="@color/black"
+            app:layout_constraintBottom_toTopOf="@id/infoTextLayer"
+            app:layout_constraintDimensionRatio="24:5"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/placeInfoLayer"
+            app:layout_constraintVertical_weight="0.15">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp">
+
+                <ImageView
+                    android:id="@+id/parkingImage"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:src="@drawable/parking_cliked"
+                    app:layout_constraintBottom_toTopOf="@id/parkingText"
+                    app:layout_constraintEnd_toStartOf="@id/infoImage"
+                    app:layout_constraintHorizontal_weight="0.1"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_weight="0.5" />
+
+                <TextView
+                    android:id="@+id/parkingText"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:gravity="center"
+                    android:text="주차"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/infoText"
+                    app:layout_constraintHorizontal_weight="0.1"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/parkingImage"
+                    app:layout_constraintVertical_weight="0.5" />
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/infoImage"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:background="@color/white"
+                    android:src="@drawable/info_24dp_31511e_fill0_wght400_grad0_opsz24"
+                    app:layout_constraintBottom_toTopOf="@id/infoText"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_weight="0.1"
+                    app:layout_constraintStart_toEndOf="@id/parkingImage"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_weight="0.5" />
+
+                <TextView
+                    android:id="@+id/infoText"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:gravity="center"
+                    android:text="문의"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_weight="0.1"
+                    app:layout_constraintStart_toEndOf="@id/parkingText"
+                    app:layout_constraintTop_toBottomOf="@id/infoImage"
+                    app:layout_constraintVertical_weight="0.5" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/infoTextLayer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:background="@color/white"
+            android:gravity="start|center"
+            android:text="대표 메뉴"
+            android:textSize="24dp"
+            app:layout_constraintBottom_toTopOf="@id/mainPlaceInfoLayer"
+            app:layout_constraintDimensionRatio="36:4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/functionInfoLayer"
+            app:layout_constraintVertical_weight="0.05" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/mainPlaceInfoLayer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/white"
+            app:layout_constraintBottom_toTopOf="@id/introText"
+            app:layout_constraintDimensionRatio="36:4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/infoTextLayer"
+            app:layout_constraintVertical_weight="0.1">
+            <TextView
+                android:id="@+id/representativeMenuText"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center|start"
+                android:text="삼겹살"
+                android:textSize="16dp" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <TextView
+            android:id="@+id/introText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@color/white"
+            android:gravity="start|center"
+            android:text="메뉴"
+            android:textSize="24dp"
+            app:layout_constraintBottom_toTopOf="@id/mainIntroText"
+            app:layout_constraintDimensionRatio="36:4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/mainPlaceInfoLayer"
+            app:layout_constraintVertical_weight="0.05" />
+
+        <TextView
+            android:id="@+id/mainIntroText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:text="가나다라마바사"
+            android:textSize="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="36:4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/introText"
+            app:layout_constraintVertical_weight="0.3" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_restrauntview.xml
+++ b/app/src/main/res/layout/fragment_restrauntview.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <com.naver.maps.map.MapView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_marker_restraunt.xml
+++ b/app/src/main/res/layout/item_marker_restraunt.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/restrauntImage"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="8dp"
+        android:layout_weight="0.2"
+        android:src="@drawable/empty" />
+
+    <TextView
+        android:id="@+id/restrauntTitle"
+        android:layout_width="150dp"
+        android:layout_height="25dp"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="8sp"
+        android:autoSizeMaxTextSize="16sp"
+        android:autoSizeStepGranularity="1sp"
+        android:gravity="center|start"
+        android:text="asd" />
+
+</LinearLayout>


### PR DESCRIPTION
# 개요
관광지 주변 음식점 정보 UI, FEAT 구현

# 상세
- 관광지 1km 반경 내의 음식점을 네이버 지도에 마커, 클러스터로 위치를 나타냄
- 마커를 클릭하면 관광지 상세 정보를 보여줌
- 관광지 상세 정보 UI 구현
![2](https://github.com/user-attachments/assets/2ffd1142-c6d1-4479-943a-56ef2fb5bf75)
![1](https://github.com/user-attachments/assets/42dd4338-314d-40ec-8f4a-2e3670ee0622)

# 이후
관광지 정보 보여주는 Process에 사용해야할 LeaveIt Server API 연결 & 데이터 매핑 작업 시작